### PR TITLE
Fix unmount to properly free anonymous block devices

### DIFF
--- a/fs/aufs/super.c
+++ b/fs/aufs/super.c
@@ -974,7 +974,7 @@ static void aufs_kill_sb(struct super_block *sb)
 		aufs_write_unlock(sb->s_root);
 		au_nwt_flush(&sbinfo->si_nowait);
 	}
-	generic_shutdown_super(sb);
+	kill_anon_super(sb);
 }
 
 struct file_system_type aufs_fs_type = {


### PR DESCRIPTION
After doing about 2^20 aufs mount/unmount cycles, further mounts of any none type filesystem (e.g., aufs, tmpfs, etc) become impossible with an error reading "mount table full" (EMFILE). The root cause seems to be that aufs_kill_sb calls generic_shutdown_super instead of kill_anon_super, skipping free_anon_bdev, leaking the dummy device that had been mounted, and causing the dummy device table (which allows 2^20 entries) to fill up.

This behavior can be reproduced using [this program](https://gist.github.com/EvanKrall/9267361).
