### PR TITLE
added #include <linux/vmalloc.h> in fs/aufs/super.c

### DIFF
--- a/fs/aufs/super.c
+++ b/fs/aufs/super.c
@@ -1,5 +1,18 @@
 /*
  * Copyright (C) 2005-2015 Junjiro R. Okajima
+ *
+ * This program, aufs is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 /*
@@ -9,6 +22,7 @@
 #include <linux/mm.h>
 #include <linux/seq_file.h>
 #include <linux/statfs.h>
+#include <linux/vmalloc.h>
 #include "aufs.h"
 
 /*


### PR DESCRIPTION
I needed to add this include, otherwise compiling super.c on ARMv7 fails with the following error:
`error: implicit declaration of function 'vzalloc'` 
